### PR TITLE
Update Slack invite link in README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/oqtopus-team/tranqu-server/actions/workflows/ci.yaml/badge.svg)](https://github.com/oqtopus-team/tranqu-server/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/oqtopus-team/tranqu-server/graph/badge.svg?token=RCXTMMXOMV)](https://codecov.io/gh/oqtopus-team/tranqu-server)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08KB2M66SD)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/oqtopus-team/tranqu-server/actions/workflows/ci.yaml/badge.svg)](https://github.com/oqtopus-team/tranqu-server/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/oqtopus-team/tranqu-server/graph/badge.svg?token=RCXTMMXOMV)](https://codecov.io/gh/oqtopus-team/tranqu-server)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08KB2M66SD)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## Overview
 


### PR DESCRIPTION
Replace the outdated Slack invite link with the current one in the README and index documentation.