### PR TITLE
chore: change default port to 51020 and rename env vars to TRANQU_* prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install: ## Install dependencies and configure git commit template
 	fi
 
 run: ## Run Tranqu Server
-	@uv run python -m tranqu_server.proto.service -c config/config.yaml -l config/logging.yaml
+	@TRANQU_WORKERS=10 TRANQU_ADDRESS="localhost:51020" uv run python -m tranqu_server.proto.service -c config/config.yaml -l config/logging.yaml
 
 format: ## Run code formatting
 	@uv run ruff check --fix
@@ -38,11 +38,11 @@ docs-serve: ## Serve documentation locally
 	@uv run mkdocs serve
 
 grpcurl-list: ## List gRPC services via grpcurl
-	@grpcurl -plaintext localhost:52020 list
+	@grpcurl -plaintext localhost:51020 list
 
 grpcurl-test: ## Run a transpile test using grpcurl
 	@grpcurl -plaintext -d '{"program": "OPENQASM 3.0; include \"stdgates.inc\"; qubit[2] q; h q[0]; cx q[0], q[1];", "program_lib": "openqasm3", "transpiler_lib": "qiskit"}' \
-		"localhost:52020" tranqu_server.proto.v1.TranspilerService.Transpile
+		"localhost:51020" tranqu_server.proto.v1.TranspilerService.Transpile
 
 help: ## Show help message
 	@echo "Usage: make [target]"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,3 @@
-proto:
-  max_workers: ${WORKERS, 10}
-  address: ${ADDRESS, "localhost:52020"}
+proto: # Settings for gRPC server
+  max_workers: ${TRANQU_WORKERS, 10} # Maximum number of workers
+  address: ${TRANQU_ADDRESS, "localhost:51020"} # Address and port for RPCs

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -47,9 +47,9 @@ Tranqu Server uses two configuration files:
 This is the main configuration file for Tranqu Server.
 
 ```yaml
-proto: # Settings for Tranqu Server as a gRPC server
-  max_workers: ${WORKERS, 10} # Maximum number of workers (default: 10)
-  address: ${ADDRESS, "localhost:52020"} # Address and port for RPCs (default: localhost:52020)
+proto: # Settings for gRPC server
+  max_workers: ${TRANQU_WORKERS, 10} # Maximum number of workers
+  address: ${TRANQU_ADDRESS, "localhost:51020"} # Address and port for RPCs
 ```
 
 ### logging.yaml
@@ -72,7 +72,7 @@ uv run python -m tranqu_server.proto.service -c config/config.yaml -l config/log
 The `WORKERS` and `ADDRESS` environment variables can be used to override the default values defined in `config.yaml`.
 
 ```shell
-WORKERS=10 ADDRESS="localhost:52020" uv run python -m tranqu_server.proto.service -c config/config.yaml -l config/logging.yaml
+TRANQU_WORKERS=10 TRANQU_ADDRESS="localhost:51020" uv run python -m tranqu_server.proto.service -c config/config.yaml -l config/logging.yaml
 ```
 
 ## Run sample client
@@ -94,7 +94,7 @@ See the [grpcurl repository](https://github.com/fullstorydev/grpcurl)
 ### List services
 
 ```shell
-grpcurl -plaintext localhost:52020 list
+grpcurl -plaintext localhost:51020 list
 ```
 
 Alternatively, you can use the shortcut defined in the Makefile:
@@ -106,7 +106,7 @@ make grpcurl-list
 ### Check supported methods
 
 ```shell
-grpcurl -plaintext "localhost:52020" list tranqu_server.proto.v1.TranspilerService
+grpcurl -plaintext "localhost:51020" list tranqu_server.proto.v1.TranspilerService
 ```
 
 ### Request to transpile
@@ -118,7 +118,7 @@ grpcurl -plaintext -d '{
   "program": "OPENQASM 3.0; include \"stdgates.inc\"; qubit[2] q; h q[0]; cx q[0], q[1];\n",
   "program_lib": "openqasm3",
   "transpiler_lib": "qiskit"
-}' "localhost:52020" tranqu_server.proto.v1.TranspilerService.Transpile
+}' "localhost:51020" tranqu_server.proto.v1.TranspilerService.Transpile
 ```
 
 You can also run this pre-defined test command via `make`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.12"
 dependencies = [
   "grpcio-reflection>=1.68.1",
   "grpcio>=1.68.1",
-  "oqtopus-util>=1.0.0",
+  "oqtopus-util>=1.0.1",
   "protobuf>=5.29.1",
   "python-json-logger>=3.2.1",
   "tranqu>=1.0.0",

--- a/src/tranqu_server/proto/service.py
+++ b/src/tranqu_server/proto/service.py
@@ -200,7 +200,7 @@ def serve(config_yaml_path: str, logging_yaml_path: str) -> None:
     setup_logging(logging_yaml)
 
     max_workers = int(config_yaml["proto"].get("max_workers") or 10)
-    address = str(config_yaml["proto"].get("address") or "localhost:52020")
+    address = str(config_yaml["proto"].get("address") or "localhost:51020")
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers))
     tranqu_pb2_grpc.add_TranspilerServiceServicer_to_server(

--- a/uv.lock
+++ b/uv.lock
@@ -713,14 +713,14 @@ parser = [
 
 [[package]]
 name = "oqtopus-util"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/fc/e9951e6fcaca2b44a8d18cf4eea1c6b7aa5236d4778ffb51da414fbf5626/oqtopus_util-1.0.0.tar.gz", hash = "sha256:4e618d92618a5bf28406d26545f42e81c2c13c5952b8da732fee171398b610a6", size = 215141, upload-time = "2026-03-22T17:06:41.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/00/fdff8bcbb51d3e9e061df44e730ae97eeb31dbb47638d8639ac29b87ca3f/oqtopus_util-1.0.1.tar.gz", hash = "sha256:a8e8b2df41905938458c0781817a72d42064d2dc31d18bc4d6eff54fe10daa5c", size = 224529, upload-time = "2026-05-26T06:06:51.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/45/86209f5863c25b8c02fc57e17350d541e83779e959cc8c35ba44751bbe48/oqtopus_util-1.0.0-py3-none-any.whl", hash = "sha256:28a9081a91a0c620f4e4565a92e9236b3cf0ce0313873b69f26c08916e0df372", size = 12101, upload-time = "2026-03-22T17:06:40.879Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5b/d094603c64100de1d63c0cbef67f689ad131acfed5290021790173f32fce/oqtopus_util-1.0.1-py3-none-any.whl", hash = "sha256:2c9efce619cca3e7e86dc33809eeac10029489ebd92e292e3af33db809f0bdce", size = 12105, upload-time = "2026-05-26T06:06:49.573Z" },
 ]
 
 [[package]]
@@ -1687,7 +1687,7 @@ test = [
 requires-dist = [
     { name = "grpcio", specifier = ">=1.68.1" },
     { name = "grpcio-reflection", specifier = ">=1.68.1" },
-    { name = "oqtopus-util", specifier = ">=1.0.0" },
+    { name = "oqtopus-util", specifier = ">=1.0.1" },
     { name = "protobuf", specifier = ">=5.29.1" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
     { name = "tranqu", specifier = ">=1.0.0" },


### PR DESCRIPTION
This pull request updates the configuration and documentation to standardize environment variable names and change the default gRPC server address and port for Tranqu Server. It also updates the Makefile and code to use these new defaults and environment variables, and bumps a dependency version.

**Configuration and environment variable updates:**

* Changed default gRPC server address from `"localhost:52020"` to `"localhost:51020"` throughout the codebase and documentation. [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL1-R3) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L41-R45) [[3]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L97-R97) [[4]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L109-R109) [[5]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L121-R121) [[6]](diffhunk://#diff-8e0603a95c1f48ae64f04f76b2f22c0c755084eb60f7a38492b90d1e6d8c6b2cL203-R203)
* Renamed environment variables from `WORKERS` and `ADDRESS` to `TRANQU_WORKERS` and `TRANQU_ADDRESS` in both the configuration (`config.yaml`) and documentation, and updated references in the Makefile and startup commands. [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL1-R3) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-R14) [[3]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L50-R52) [[4]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L75-R75)

**Documentation and Makefile updates:**

* Updated all relevant documentation (`docs/usage/getting_started.md`) and Makefile targets to use the new environment variable names and default address/port. [[1]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L50-R52) [[2]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L75-R75) [[3]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L97-R97) [[4]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L109-R109) [[5]](diffhunk://#diff-89185ca0595d08dd982bca75fa220d2c5d5d6e4da224667937481f2ad0035c52L121-R121) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-R14) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L41-R45)

**Dependency update:**

* Bumped `oqtopus-util` dependency from version `1.0.0` to `1.0.1` in `pyproject.toml`.